### PR TITLE
Encode special characters for HTML output

### DIFF
--- a/src/nim_playground.nim
+++ b/src/nim_playground.nim
@@ -1,4 +1,4 @@
-import jester, asyncdispatch, os, osproc, strutils, json, threadpool, asyncfile, asyncnet, posix, logging, nuuid, tables, httpclient
+import jester, asyncdispatch, os, osproc, strutils, json, threadpool, asyncfile, asyncnet, posix, logging, nuuid, tables, httpclient, cgi
 
 type
   Config = object
@@ -44,8 +44,8 @@ proc respondOnReady(fv: FlowVar[TaintedString], requestConfig: ptr RequestConfig
       
       var errorsFile = openAsync("$1/errors.txt" % requestConfig.tmpDir, fmReadWrite)
       var logFile = openAsync("$1/logfile.txt" % requestConfig.tmpDir, fmReadWrite)
-      var errors = await errorsFile.readAll()
-      var log = await logFile.readAll()
+      var errors = await errorsFile.readAll().xmlEncode()
+      var log = await logFile.readAll().xmlEncode()
       
       var ret = %* {"compileLog": errors, "log": log}
       


### PR DESCRIPTION
Encode the characters '<', '&', '>' and '"' to entities "&lt;", "&amp;",
"&gt;" and "&quot;", respectively, before they're sent to the browser.
Otherwise "<...>" sequences are interpreted as (likely invalid) HTML
tags by the browser and aren't displayed (see ticket #4).

The encoding is done with `cgi.xmlEncode` from the standard library, see
https://nim-lang.github.io/Nim/cgi.html#xmlEncode%2Cstring .